### PR TITLE
switch yaml.load to yaml.safe_load

### DIFF
--- a/ecr_api.py
+++ b/ecr_api.py
@@ -844,7 +844,7 @@ class Apps(MethodView):
             # try yaml
             yaml_str = request.get_data().decode("utf-8")
             print(f"yaml_str: {yaml_str} ", file=sys.stderr)
-            postData = yaml.load(yaml_str, Loader=yaml.FullLoader)
+            postData = yaml.safe_load(yaml_str)
 
         if not postData:
             raise ErrorResponse(


### PR DESCRIPTION
This PR is to address https://github.com/waggle-sensor/sage-ecr/security/code-scanning/9.

I am not sure how to reproduce the exact vulnerability with newer versions of PyYAML's `yaml.load` but I confirmed that at one point it have have been possible to do something like:

```
# the data in quotes is valid yaml!!
In [31]: yaml.unsafe_load("!!python/object/new:os.system [date]")
Wed May 10 14:46:11 CDT 2023
```

To be safe, I'm converting any load into a safe_load.

This would allow a user with a malicious `sage.yaml` file to run arbitrary code inside ECR. (Ex. copy some token and then run curl to post token to external server.)