### PR TITLE
check that user build artifact lives directly in tempdir

### DIFF
--- a/ecr_api.py
+++ b/ecr_api.py
@@ -260,9 +260,7 @@ def preprocess_repository(url, branchOrTag, custom_version, namespace, repositor
 
         # check that user submission artifact lives directly in temp_dir
         if os.path.dirname(target_gzip) != temp_dir:
-            raise Exception(
-                "User submission has invalid namespace, repository or version."
-            )
+            raise Exception(f"Invalid repo gzip artifact path: {target_gzip}")
 
         # tar -czvf file.tar.gz directory
         command = ["tar", "-czvf", target_gzip, "."]

--- a/ecr_api.py
+++ b/ecr_api.py
@@ -189,11 +189,7 @@ def preprocess_repository(url, branchOrTag, custom_version, namespace, repositor
     git_hash_long = ""
 
     temp_dir = config.ecr_temp_dir
-
-    if not os.path.exists(temp_dir):
-        os.makedirs(temp_dir)
-
-    wait_count = 0
+    os.makedirs(temp_dir, exist_ok=True)
 
     with tempfile.TemporaryDirectory(dir=temp_dir) as tmpdirname:
         app.logger.debug(f"tmpdirname: {tmpdirname}")
@@ -260,8 +256,15 @@ def preprocess_repository(url, branchOrTag, custom_version, namespace, repositor
         else:
             final_version = version
 
-        # tar -czvf file.tar.gz directory
         target_gzip = f"{temp_dir}/{namespace}_{repository}_{final_version}.tgz"
+
+        # check that user submission artifact lives directly in temp_dir
+        if os.path.dirname(target_gzip) != temp_dir:
+            raise Exception(
+                "User submission has invalid namespace, repository or version."
+            )
+
+        # tar -czvf file.tar.gz directory
         command = ["tar", "-czvf", target_gzip, "."]
         stdout, stderr, exit_code = run_command_communicate(command, cwd=tmpdirname)
         stdout_str = ""

--- a/ecr_api.py
+++ b/ecr_api.py
@@ -260,7 +260,13 @@ def preprocess_repository(url, branchOrTag, custom_version, namespace, repositor
 
         # check that user submission artifact lives directly in temp_dir
         if os.path.dirname(target_gzip) != temp_dir:
-            raise Exception(f"Invalid repo gzip artifact path: {target_gzip}")
+            app.logger.error(
+                "preprocess_repository: invalid repo gzip artifact path: %s",
+                target_gzip,
+            )
+            raise Exception(
+                f"Invalid submission! Check that namespace, repository and version are all valid."
+            )
 
         # tar -czvf file.tar.gz directory
         command = ["tar", "-czvf", target_gzip, "."]


### PR DESCRIPTION
This PR addresses https://github.com/waggle-sensor/sage-ecr/security/code-scanning/13 by ensuring user build artifact lives directly in temp dir.